### PR TITLE
Missing CommonJS file in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dist/**/*"
   ],
   "scripts": {
+    "prepublishOnly": "rm dist/* -f && npm run build",
     "build": "rollup -c",
     "test": "jest"
   },


### PR DESCRIPTION
The file `max-validator/dist/max-validator.js` is missing on npm
I've added a script to rebuild the dist folder, so it will be fixed next release